### PR TITLE
added precompile

### DIFF
--- a/src/Maxima.jl
+++ b/src/Maxima.jl
@@ -1,6 +1,7 @@
 # This file is part of Maxima.jl. It is licensed under the MIT license
 #   Copyright (c) 2016 Nathan Smith
 
+__precompile__()
 module Maxima
 
 using Compat

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -6,7 +6,7 @@ __init__() = (LoadMaxima(); atexit(() -> kill(ms)))
 
 function LoadMaxima()
     try
-	    is_unix() ? @compat	readstring(`maxima --version`) : 
+	    is_unix() ? (@compat readstring(`maxima --version`)) : 
             @compat readstring(`maxima.bat --version`)
     catch err
         error("Looks like Maxima is either not installed or not in the path")

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -1,25 +1,29 @@
 # 	This file is part of Maxima.jl. It is licensed under the MIT license
 #   Copyright (c) 2016 Nathan Smith
 
-try
-	if is_unix()
-		@compat	readstring(`maxima --version`)
-	else
-		@compat readstring(`maxima.bat --version`)
+ResetMaxima() = (kill(ms); LoadMaxima())
+__init__() = (LoadMaxima(); atexit(() -> kill(ms)))
+
+function LoadMaxima()
+	try
+		if is_unix()
+			@compat	readstring(`maxima --version`)
+		else
+			@compat readstring(`maxima.bat --version`)
+		end
+	catch err
+		error("Looks like Maxima is either not installed or not in the path")
 	end
-catch err
-	error("Looks like Maxima is either not installed or not in the path")
-end
 
-# Server setup
+	# Server setup
 
-const ms = MaximaSession()	# Spin up a Maxima session
-atexit(() -> kill(ms))  	# Kill the session on exit
+	global ms = MaximaSession()	# Spin up a Maxima session
 
-# REPL setup
-repl_active = isdefined(Base, :active_repl)	# Is an active repl defined?
-interactive = isinteractive()				# In interactive mode?
+	# REPL setup
+	repl_active = isdefined(Base, :active_repl)	# Is an active repl defined?
+	interactive = isinteractive()				# In interactive mode?
 
-if repl_active && interactive
-	repl_init(Base.active_repl)
+	if repl_active && interactive
+		repl_init(Base.active_repl)
+	end
 end

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -1,29 +1,26 @@
-# 	This file is part of Maxima.jl. It is licensed under the MIT license
+#   This file is part of Maxima.jl. It is licensed under the MIT license
 #   Copyright (c) 2016 Nathan Smith
 
 ResetMaxima() = (kill(ms); LoadMaxima())
 __init__() = (LoadMaxima(); atexit(() -> kill(ms)))
 
 function LoadMaxima()
-	try
-		if is_unix()
-			@compat	readstring(`maxima --version`)
-		else
-			@compat readstring(`maxima.bat --version`)
-		end
-	catch err
-		error("Looks like Maxima is either not installed or not in the path")
-	end
+    try
+	    is_unix() ? @compat	readstring(`maxima --version`) : 
+            @compat readstring(`maxima.bat --version`)
+    catch err
+        error("Looks like Maxima is either not installed or not in the path")
+    end
 
 	# Server setup
 
-	global ms = MaximaSession()	# Spin up a Maxima session
+    global ms = MaximaSession()	# Spin up a Maxima session
 
 	# REPL setup
-	repl_active = isdefined(Base, :active_repl)	# Is an active repl defined?
-	interactive = isinteractive()				# In interactive mode?
+    repl_active = isdefined(Base, :active_repl)	# Is an active repl defined?
+    interactive = isinteractive()				# In interactive mode?
 
-	if repl_active && interactive
-		repl_init(Base.active_repl)
-	end
+    if repl_active && interactive
+	    repl_init(Base.active_repl)
+    end
 end


### PR DESCRIPTION
Added precompilation to the package / module

For this to be convenient, I also wrapped your `setup.jl` code in a function called `ResetMaxima()`, which enables you to kill and restart your maxima pipe without reloading the `Maxima.jl` package.

In order for this to work, `ms` must be defined as `global` instead of `const`.

For the precompilation to work, you need an `__init__()` function that does not get precompiled. Instead, this function only gets called when you actually load the package. You will get a heap allocation error if you also precompile your maxima session. Thus, the maxima session is only initialized when the package is loaded instead of also being precompiled. As a bonus, you also get to reset your session with no hassles. :)