### PR TITLE
Parse Quoteblock + Function

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -13,7 +13,7 @@ show(io::IO, m::MExpr) = print(io, convert(Compat.String, m))
 @compat function show(io::IO, ::MIME"text/plain", m::MExpr)
   input = "'("*replace(convert(Compat.String, m), r";",");\n'(")*")"
 	write(ms.input, "$(replace(input,r";","\$"))\$\n print(ascii(4))\$")
-	out = (readuntil(ms.output, EOT) |> String
+	out = (readuntil(ms.output, EOT) |> Compat.String
 								     |> str -> rstrip(str, EOT))
 	if contains(out, synerr) || contains(out, maxerr)
 		warn("Invalid Maxima expression")
@@ -35,7 +35,7 @@ end
 @compat function show(io::IO, ::MIME"text/latex", m::MExpr)
   check = "'("*replace(convert(Compat.String, m), r";",")\$\n'(")*")"
 	write(ms.input, "$check\$\n print(ascii(4))\$")
-	out = (readuntil(ms.output, EOT) |> String
+	out = (readuntil(ms.output, EOT) |> Compat.String
 								     |> str -> rstrip(str, EOT))
 	if contains(out, synerr) || contains(out, maxerr)
 		warn("Invalid Maxima expression")

--- a/src/io.jl
+++ b/src/io.jl
@@ -7,36 +7,42 @@ export string,
 import Base: string,
              show
 
-string(m::MExpr) = m.str
-show(io::IO, m::MExpr) = print(io, m.str)
+string(m::MExpr) = convert(Compat.String, m)
+show(io::IO, m::MExpr) = print(io, convert(Compat.String, m))
 
 @compat function show(io::IO, ::MIME"text/plain", m::MExpr)
-	write(ms.input, "'($m)\$\n print(ascii(4))\$")
-	out = (readuntil(ms.output, EOT) |> String 
+  input = "'("*replace(convert(Compat.String, m), r";",");\n'(")*")"
+	write(ms.input, "$(replace(input,r";","\$"))\$\n print(ascii(4))\$")
+	out = (readuntil(ms.output, EOT) |> String
 								     |> str -> rstrip(str, EOT))
 	if contains(out, synerr) || contains(out, maxerr)
 		warn("Invalid Maxima expression")
 		print(io, out)
 	else
 		mcall(m"display2d: true")
-		write(ms, "'($m)")
+		write(ms, replace(input,r";","; print(ascii(3))\$ "))
 		str = read(ms)
+    #show(str)
 		str = rstrip(str, '\n')
 		mcall(m"display2d: false")
-		print(io, str)
+    sp = split(str, "\x03")
+    for k in 1:length(sp)
+      print(io, sp[k])
+    end
 	end
 end
 
 @compat function show(io::IO, ::MIME"text/latex", m::MExpr)
-	write(ms.input, "'($m)\$\n print(ascii(4))\$")
-	out = (readuntil(ms.output, EOT) |> String 
+  check = "'("*replace(convert(Compat.String, m), r";",")\$\n'(")*")"
+	write(ms.input, "$check\$\n print(ascii(4))\$")
+	out = (readuntil(ms.output, EOT) |> String
 								     |> str -> rstrip(str, EOT))
 	if contains(out, synerr) || contains(out, maxerr)
 		warn("Invalid Maxima expression")
 		print(io, out)
 	else
-		write(ms, "tex('($m))\$")
+		write(ms, "tex('("*replace(convert(Compat.String, m), r";","))\$\ntex('(")*"))")
 		texstr = read(ms)
-		print(io, texstr)
+		print(io, replace(texstr,r"\nfalse\n",""))
 	end
 end

--- a/src/mexpr.jl
+++ b/src/mexpr.jl
@@ -59,7 +59,7 @@ function show_expr(io::IO, expr::Expr)
         show_expr(io,expr.args[2])
     elseif expr.head == :function
         show_expr(io,expr.args[1])
-        print(io," = block([], ")
+        print(io," := block([], ")
         args = expr.args[2].args
         for (i, arg) in enumerate(args)
             show_expr(io, arg)
@@ -129,7 +129,7 @@ const m_to_jl = Dict("%e" => "e",
     "inf"   =>  "Inf",
     "minf"  =>  "-Inf")
 
-const m_to_jl_utf = Dict(":=" => "=")
+const m_to_jl_utf = Dict(":" => "=")
 
 const jl_to_m = Dict("e" => "%e",
     "eu" => "%e",
@@ -142,10 +142,7 @@ const jl_to_m = Dict("e" => "%e",
     "im" => "%i",
     "Inf" => "inf")
 
-const jl_to_m_utf = Dict("=" => ":=")
-
 const repmjl = Dict(m_to_jl...,m_to_jl_utf...)
-const repjlm = Dict(jl_to_m...,jl_to_m_utf...)
 
 _subst(a, b, expr) = "subst($a, $b, '($expr))" |> MExpr |> mcall
 
@@ -166,9 +163,8 @@ function MExpr(expr::Expr)
 	#str = "$expr"
   str = unparse(expr)
   for h in 1:length(str)
-    for key in keys(repjlm)
-        str[h] = replace(str[h],key,repjlm[key])
-        #str[h] = _subst(jl_to_m[key], key, str[h])
+    for key in keys(jl_to_m)
+        str[h] = _subst(jl_to_m[key], key, str[h])
     end
   end
   return MExpr(str)

--- a/src/mexpr.jl
+++ b/src/mexpr.jl
@@ -66,7 +66,7 @@ function show_expr(io::IO, expr::Expr)
             i != endof(args) ? print(io, ", ") : print(io, ")")
         end
     else
-      error("Nested :$(expr.head) block structure not supported by Reduce.jl")
+      error("Nested :$(expr.head) block structure not supported by Maxima.jl")
     end
 end
 
@@ -81,7 +81,7 @@ function unparse(expr::Expr)
     return str
 	else
     show_expr(io, expr)
-    return push!(str,String(io))
+    return push!(str,Compat.String(io))
   end
 end
 
@@ -101,7 +101,7 @@ type MExpr
 	str::Array{Compat.String,1}
   MExpr(m::Array{Compat.String,1}) = new(m)
 end
-MExpr(m::Array{SubString{String},1}) = MExpr(convert(Array{Compat.String,1},m))
+MExpr(m::Array{SubString{Compat.String},1}) = MExpr(convert(Array{Compat.String,1},m))
 MExpr(str::Compat.String) = MExpr(push!(Array{Compat.String,1}(0),str))
 MExpr(m::Any) = MExpr("$m")
 
@@ -187,18 +187,18 @@ function parse(m::MExpr)
     end
     if contains(sexpr[h],":=")
       sp = split(sexpr[h],":=")
-      push!(pexpr,Expr(:function,parse(sp[1]),sp[2] |> String |> MExpr |> parse))
+      push!(pexpr,Expr(:function,parse(sp[1]),sp[2] |> Compat.String |> MExpr |> parse))
     elseif contains(sexpr[h],"block([],")
       rp = replace(sexpr[h],"block([],","") |> chop
       sp = split(rp,",")
       ep = Array{Any,1}(length(sp))
       for u in 1:length(sp)
-        ep[u] = sp[u] |> String |> MExpr |> parse
+        ep[u] = sp[u] |> Compat.String |> MExpr |> parse
       end
       push!(pexpr,Expr(:block,ep...))
     elseif contains(sexpr[h],":")
       sp = split(sexpr[h],":")
-      push!(pexpr,Expr(:(=),parse(sp[1]),sp[2] |> String |> MExpr |> parse))
+      push!(pexpr,Expr(:(=),parse(sp[1]),sp[2] |> Compat.String |> MExpr |> parse))
     else
       push!(pexpr,parse(sexpr[h]))
     end
@@ -234,7 +234,7 @@ julia> mcall(ans)
 ```
 """
 function mcall(m::MExpr)
-    write(ms, replace(convert(String,m),r";","; print(ascii(3))\$ "))
+    write(ms, replace(convert(Compat.String,m),r";","; print(ascii(3))\$ "))
     output = read(ms)
     if contains(output, maxerr)
 		    write(ms.input, "errormsg()\$")

--- a/src/mexpr.jl
+++ b/src/mexpr.jl
@@ -93,10 +93,10 @@ macro m_str(str)
 end
 
 const m_to_jl = Dict("%e" => "e",
-    "%pi"   =>  "π",
+    "%pi"   =>  "pi",
     "%i"    =>  "im",
     "%gamma" => "eulergamma",
-    "%phi"  =>  "φ",
+    "%phi"  =>  "golden",
     "inf"   =>  "Inf",
     "minf"  =>  "-Inf")
 
@@ -150,7 +150,7 @@ julia> parse(m\"sin(%i*x)\")
 ```
 """
 function parse(m::MExpr)
-  pexpr = Array{Expr,1}(0); sexpr = Array{Compat.String,1}(0)
+  pexpr = Array{Any,1}(0); sexpr = Array{Compat.String,1}(0)
   for h in 1:length(m.str)
     sp = split(replace(m.str[h],r"\$",";"),';')
     for str in sp
@@ -166,7 +166,7 @@ function parse(m::MExpr)
   return length(pexpr) == 1 ? pexpr[1] : Expr(:block,pexpr...)
 end
 
-
+convert(::Type{MExpr}, m::MExpr) = m
 convert(::Type{Compat.String}, m::MExpr) = join(m.str,"; ")
 convert(::Type{Expr}, m::MExpr) = parse(m)
 if VERSION < v"0.5.0"

--- a/src/mexpr.jl
+++ b/src/mexpr.jl
@@ -60,9 +60,9 @@ function show_expr(io::IO, expr::Expr)
     elseif expr.head == :function
         show_expr(io,expr.args[1])
         print(io," := block([], ")
-        args = expr.args[2].args
+        args = unparse(expr.args[2])
         for (i, arg) in enumerate(args)
-            show_expr(io, arg)
+            print(io,arg)
             i != endof(args) ? print(io, ", ") : print(io, ")")
         end
     else
@@ -159,8 +159,26 @@ function MExpr(expr::Expr)
 	#str = "$expr"
   str = unparse(expr)
   for h in 1:length(str)
-    for key in keys(jl_to_m)
+    for key in keys(jl_to_m) #=
+      if contains(str[h],":=")
+        sp = split(str[h],":=")
+        str[h] = String(str[1])*":="*(_subst(jl_to_m[key],key,String(sp[2]))).str
+      elseif contains(str[h],"block([],")
+        rp = replace(str[h],"block([],","") |> chop
+        sp = split(rp,",")
+        ns = "block([],"
+        for u in 1:length(sp)
+          ns = ns*(_subst(jl_to_m[key],key,String(sp[u]))).str
+        end
+        ns = ns*")"
+        str[h] = ns
+      elseif contains(str[h],":")
+        sp = split(str[h],":")
+        str[h] = String(sp[1])*":"*(_subst(jl_to_m[key],key,String(sp[2]))).str
+      else
         str[h] = _subst(jl_to_m[key], key, str[h])
+      end =#
+      str[h] = _subst(jl_to_m[key], key, str[h])
     end
   end
   return MExpr(str)

--- a/src/mexpr.jl
+++ b/src/mexpr.jl
@@ -53,6 +53,18 @@ function show_expr(io::IO, expr::Expr)
             show_expr(io, arg)
             i != endof(args) ? print(io, seperator) : print(io, ")")
         end
+    elseif expr.head == :(=)
+        show_expr(io,expr.args[1])
+        print(io,": ")
+        show_expr(io,expr.args[2])
+    elseif expr.head == :function
+        show_expr(io,expr.args[1])
+        print(io," = block([], ")
+        args = expr.args[2].args
+        for (i, arg) in enumerate(args)
+            show_expr(io, arg)
+            i != endof(args) ? print(io, ", ") : print(io, ")")
+        end
     else
       error("Nested :$(expr.head) block structure not supported by Reduce.jl")
     end

--- a/src/mexpr.jl
+++ b/src/mexpr.jl
@@ -159,25 +159,7 @@ function MExpr(expr::Expr)
 	#str = "$expr"
   str = unparse(expr)
   for h in 1:length(str)
-    for key in keys(jl_to_m) #=
-      if contains(str[h],":=")
-        sp = split(str[h],":=")
-        str[h] = String(str[1])*":="*(_subst(jl_to_m[key],key,String(sp[2]))).str
-      elseif contains(str[h],"block([],")
-        rp = replace(str[h],"block([],","") |> chop
-        sp = split(rp,",")
-        ns = "block([],"
-        for u in 1:length(sp)
-          ns = ns*(_subst(jl_to_m[key],key,String(sp[u]))).str
-        end
-        ns = ns*")"
-        str[h] = ns
-      elseif contains(str[h],":")
-        sp = split(str[h],":")
-        str[h] = String(sp[1])*":"*(_subst(jl_to_m[key],key,String(sp[2]))).str
-      else
-        str[h] = _subst(jl_to_m[key], key, str[h])
-      end =#
+    for key in keys(jl_to_m)
       str[h] = _subst(jl_to_m[key], key, str[h])
     end
   end

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -39,7 +39,7 @@ function respond(repl, main)
         end
         if !isempty(strip(input))
 		    try
-                global ans = MExpr(input[1:end-1]) |> mcall |> MExpr
+                global ans = MExpr(input[1:end-1]) |> mcall
                 REPL.reset(repl)
                 if input[end] == ';'
 		            REPL.print_response(repl, ans, nothing, true, Base.have_color)
@@ -72,7 +72,7 @@ function LineEdit.complete_line(c::MaximaCompletionProvider, s)
     # complete latex
     full = LineEdit.input_string(s)
     ret, range, should_complete = REPLCompletions.bslash_completions(full, endof(partial))[2]
-
+    
 	if length(ret) > 0 && should_complete
         return ret, partial[range], true
     end

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -39,7 +39,7 @@ function respond(repl, main)
         end
         if !isempty(strip(input))
 		    try
-                global ans = MExpr(input[1:end-1])
+                global ans = MExpr(input[1:end-1]) |> mcall |> MExpr
                 REPL.reset(repl)
                 if input[end] == ';'
 		            REPL.print_response(repl, ans, nothing, true, Base.have_color)

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -39,7 +39,7 @@ function respond(repl, main)
         end
         if !isempty(strip(input))
 		    try
-                global ans = MExpr(input[1:end-1]) |> mcall
+                global ans = MExpr(input[1:end-1])
                 REPL.reset(repl)
                 if input[end] == ';'
 		            REPL.print_response(repl, ans, nothing, true, Base.have_color)
@@ -72,7 +72,7 @@ function LineEdit.complete_line(c::MaximaCompletionProvider, s)
     # complete latex
     full = LineEdit.input_string(s)
     ret, range, should_complete = REPLCompletions.bslash_completions(full, endof(partial))[2]
-    
+
 	if length(ret) > 0 && should_complete
         return ret, partial[range], true
     end

--- a/src/server.jl
+++ b/src/server.jl
@@ -2,33 +2,33 @@
 #   Copyright (c) 2016 Nathan Smith
 
 const EOT = Char(4)					# end of transmission character
-const synerr = "incorrect syntax" 
-const maxerr = "-- an error" 
+const synerr = "incorrect syntax"
+const maxerr = "-- an error"
 
 
 immutable MaximaSession <: Base.AbstractPipe
-	
+
 	input::Pipe
 	output::Pipe
 	process::Base.Process
-	
+
 	function MaximaSession()
 		# If windows, executable is .bat
 		cmd = is_unix() ? `maxima --very-quiet` :
 			`maxima.bat --very-quiet`
-		
+
 		# Setup pipes and maxima process
 		input = Pipe()
 		output = Pipe()
 		process = spawn(cmd, (input, output, STDERR))
 
-		# Close the unneeded ends of Pipes	
+		# Close the unneeded ends of Pipes
 		close(input.out)
 		close(output.in)
-	
+
 		# Set display to 1-dimensionsal
 		write(input, "display2d: false\$")
-	
+
 		return new(input, output, process)
 	end
 end
@@ -45,7 +45,7 @@ end
 
 
 if VERSION < v"0.5.0"
-    
+
     function Base.write(ms::MaximaSession, input::UTF8String)
         write(ms.input, "$input;\n")
         write(ms.input, "print(ascii(4))\$")
@@ -60,6 +60,6 @@ end
 
 
 function Base.read(ms::MaximaSession)
-	(readuntil(ms.output, EOT) |> String 
-	                           |> str -> rstrip(str, EOT)) 
+	(readuntil(ms.output, EOT) |> Compat.String 
+	                           |> str -> rstrip(str, EOT))
 end

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -1,10 +1,10 @@
 #   This file is part of Maxima.jl. It is licensed under the MIT license
 #   Copyright (c) 2016 Nathan Smith
 
-ResetMaxima() = (kill(ms); LoadMaxima())
-__init__() = (LoadMaxima(); atexit(() -> kill(ms)))
+Reset() = (kill(ms); Load())
+__init__() = (Load(); atexit(() -> kill(ms)))
 
-function LoadMaxima()
+function Load()
     try
 	    is_unix() ? (@compat readstring(`maxima --version`)) :
             @compat readstring(`maxima.bat --version`)
@@ -22,8 +22,12 @@ function LoadMaxima()
 
     if repl_active && interactive
 	    repl_init(Base.active_repl)
+    else # package is loaded from ~/.juliarc.jl
+      atreplinit() do repl # check if OhMyREPL is loaded
+        !isdefined(Main,:OhMyREPL) && (repl.interface = Base.REPL.setup_interface(repl))
+        repl_init(Base.active_repl)
+      end
     end
 
-    #write(ms,"print(ascii(3))")
-    readavailable(ms.output)
+    mcall("1") # clears out any initial data
 end

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -6,7 +6,7 @@ __init__() = (LoadMaxima(); atexit(() -> kill(ms)))
 
 function LoadMaxima()
     try
-	    is_unix() ? (@compat readstring(`maxima --version`)) : 
+	    is_unix() ? (@compat readstring(`maxima --version`)) :
             @compat readstring(`maxima.bat --version`)
     catch err
         error("Looks like Maxima is either not installed or not in the path")
@@ -23,4 +23,7 @@ function LoadMaxima()
     if repl_active && interactive
 	    repl_init(Base.active_repl)
     end
+
+    #write(ms,"print(ascii(3))")
+    readavailable(ms.output)
 end

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -1,27 +1,8 @@
 #   This file is part of Maxima.jl. It is licensed under the MIT license
 #   Copyright (c) 2016 Nathan Smith
 
-export float,
-       subst,
-       ratsimp,
-       radcan,
-       factor,
-       gfactor,
-       expand,
-       logcontract,
-       logexpand,
-       makefact,
-       makegamma,
-       trigsimp,
-       trigreduce,
-       trigexpand,
-       trigrat,
-       rectform,
-       polarform,
-       realpart,
-       imagpart,
-       demoivre,
-       exponentialize
+export subst,
+       logexpand
 
 import Base: expand,
              diff,
@@ -31,7 +12,44 @@ if VERSION < v"0.6-"
     import Base: factor
 end
 
-"""
+simfuns = [
+  :ratsimp,:radcan,
+  :factor,:gfactor,:expand,
+  :logcontract,
+  :makefact,:makegamma,
+  :trigsimp,:trigreduce,:trigexpand,:trigrat,
+  :rectform,:polarform,
+  :realpart,:imagpart,
+  :demoivre,
+  :exponentialize
+  :float]
+
+:(export $(simfuns...)) |> eval
+
+for i ∈ simfuns
+  for t ∈ [:(Compat.String),:Expr]
+    quote
+      function $i(expr::$t)
+        mexpr = MExpr(expr)
+        out = mcall(MExpr($(string(i))*"($mexpr)"))
+        convert($t, out)
+      end
+    end |> eval
+  end
+  quote
+    function $i(expr::MExpr)
+      mcall(MExpr($(string(i))*"($expr)"))
+    end
+  end |> eval
+end
+
+#function $i{T}(expr::T)
+#  mexpr = MExpr(expr)
+#  out = mcall(MExpr($(string(i))*"($mexpr)"))
+#  convert(T, out)
+#end
+
+@doc """
     ratsimp{T}(expr::T)
 
 Simplify expression.
@@ -46,17 +64,12 @@ julia> ratsimp(:(sin(asin(a + b/c))))
 :((a * c + b) / c)
 
 julia> ratsimp(m\"%e^log(x)\")
- 
+
                                        x
 ```
-"""
-function ratsimp{T}(expr::T)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("ratsimp($mexpr)"))
-    convert(T, out)
-end
+""" ratsimp
 
-"""
+@doc """
     radcan{T}(expr::T)
 
 Simplify radicals in expression.
@@ -67,21 +80,15 @@ julia> radcan(:(sqrt(x/y)))
 :(sqrt(x)/sqrt(y))
 
 julia> radcan(m\"sqrt(x/y)\")
- 
+
                                     sqrt(x)
                                     -------
                                     sqrt(y)
 
 ```
-"""
-function radcan{T}(expr::T)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("radcan($mexpr)"))
-    convert(T, out)
-end
+""" radcan
 
-
-"""
+@doc """
     factor{T}(expr::T)
 
 Factorize polynomial expression
@@ -93,18 +100,13 @@ julia> factor(:(x^2 + 2x + 1))
 :((x + 1) ^ 2)
 
 julia> factor(MExpr(\"a^2 - b^2\"))
- 
+
                                 (a - b) (b + a)
 
 ```
-"""
-function factor{T}(expr::T)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("factor($mexpr)"))
-    convert(T, out)
-end
+""" factor
 
-"""
+@doc """
     gfactor{T}(expr::T)
 
 Factorize complex polynomial expression
@@ -116,53 +118,28 @@ julia> gfactor(:(z^2 + 2*im*z - 1))
 :((z + im) ^ 2)
 
 ```
-"""
-function gfactor{T}(expr::T)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("gfactor($mexpr)"))
-    convert(T, out)
-end
+""" gfactor
 
 """
     expand(expr)
 
-Expand expression. 
+Expand expression.
 
 ## Examples
 ```julia
 julia> expand(m\"(a + b)^2\")
- 
+
                                  2            2
                                 b  + 2 a b + a
 
 ```
-"""
-function expand(expr::Compat.String)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("expand($mexpr)"))
-    convert(Compat.String, out)
-end
+""" expand
 
-function expand(expr::Expr)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("expand($mexpr)"))
-    convert(Expr, out)
-end
-
-function expand(expr::MExpr)
-    mcall(MExpr("expand($expr)"))
-end
-
-"""
+@doc """
     logcontract{T}(expr::T)
 
 Contract logarithms in expression
-"""
-function logcontract{T}(expr::T)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("logcontract($mexpr)"))
-    convert(T, out)
-end
+""" logcontract
 
 """
     logexpand{T}(expr::T)
@@ -175,29 +152,19 @@ function logexpand{T}(expr::T)
     convert(T, out)
 end
 
-"""
+@doc """
     makefact{T}(expr::T)
 
 Convert expression into factorial form.
-"""
-function makefact{T}(expr::T)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("makefact($mexpr)"))
-    convert(T, out)
-end
+""" makefact
 
-"""
+@doc """
     makegamma{T}(expr::T)
 
 Convert factorial to gamma functions in expression
-"""
-function makegamma{T}(expr::T)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("makegamma($mexpr)"))
-    convert(T, out)
-end
+""" makegamma
 
-"""
+@doc """
     trigsimp{T}(expr::T)
 
 Simplify trigonometric expression
@@ -205,39 +172,24 @@ Simplify trigonometric expression
 ## Examples
 ```julia
 julia> trigsimp(m\"sin(x)^2 + cos(x)^2\")
- 
+
                                        1
 ```
-"""
-function trigsimp{T}(expr::T)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("trigsimp($mexpr)"))
-    convert(T, out)
-end
+""" trigsimp
 
-"""
+@doc """
     trigreduce(expr)
 
 Contract trigonometric functions
-"""
-function trigreduce{T}(expr::T)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("trigreduce($mexpr)"))
-    convert(T, out)
-end
+""" trigreduce
 
-"""
+@doc """
     trigexpand(expr)
 
 Expand out trig functions in expression
-"""
-function trigexpand{T}(expr::T)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("trigexpand($mexpr)"))
-    convert(T, out)
-end
+""" trigexpand
 
-"""
+@doc """
     trigrat(expr)
 
 Convert expression into a canonical trigonometric form
@@ -248,14 +200,9 @@ julia> trigrat(:(exp(im*x) + exp(-im*x)))
 :(2 * cos(x))
 
 ```
-"""
-function trigrat{T}(expr::T)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("trigrat($mexpr)"))
-    convert(T, out)
-end
+""" trigrat
 
-"""
+@doc """
     rectform(expr)
 
 Put complex expression in rectangular form
@@ -267,14 +214,9 @@ julia> rectform(:(R*e^(im*θ)))
 
 
 ```
-"""
-function rectform{T}(expr::T)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("rectform($mexpr)"))
-    convert(T, out)
-end
+""" rectform
 
-"""
+@doc """
     polarform(expr)
 
 Put a complex expression into polarform
@@ -282,19 +224,14 @@ Put a complex expression into polarform
 ## Examples
 ```julia
 julia> polarform(m\"a + %i*b\")
- 
+
                               2    2    %i atan2(b, a)
                         sqrt(b  + a ) %e
 
 ```
-"""
-function polarform{T}(expr::T)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("polarform($mexpr)"))
-    convert(T, out)
-end
+""" polarform
 
-"""
+@doc """
     realpart(expr)
 
 Find the real part of a complex expression
@@ -306,15 +243,9 @@ julia> realpart(MExpr(\"a + %i*b\"))
                             a
 
 ```
-"""
-function realpart{T}(expr::T)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("realpart($mexpr)"))
-    convert(T, out)
-end
+""" realpart
 
-
-"""
+@doc """
     imagpart(expr)
 
 Find the imaginary part of a complex expression.
@@ -326,47 +257,37 @@ julia> realpart(MExpr(\"a + %i*b\"))
                             b
 
 ```
-"""
-function imagpart{T}(expr::T)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("imagpart($mexpr)"))
-    convert(T, out)
-end
+""" imagpart
 
-"""
+@doc """
     demoivre(expr)
 
-Break exponential terms into hyperbolic and trigonometric functions. Roughly the 
+Break exponential terms into hyperbolic and trigonometric functions. Roughly the
 opposite in function to `exponentialize`
 
 ## Examples
 ```julia
 julia> demoivre(m\"exp(a + %i * b)\")
- 
+
                              a
                            %e  (%i sin(b) + cos(b))
 
 julia> exponentialize(ans)
- 
+
                          %i b     - %i b     %i b     - %i b
                     a  %e     + %e         %e     - %e
                   %e  (----------------- + -----------------)
                                2                   2
 
 julia> expand(ans)
- 
+
                                     %i b + a
                                   %e
 
 ```
-"""
-function demoivre{T}(expr::T)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("demoivre($mexpr)"))
-    convert(T, out)
-end
+""" demoivre
 
-"""
+@doc """
     exponentialize(expr)
 
 Express expression in terms of exponents as much as possible
@@ -374,21 +295,16 @@ Express expression in terms of exponents as much as possible
 ## Examples
 ```julia
 julia> exponentialize(m\"sin(x)\")
- 
+
                                    %i x     - %i x
                              %i (%e     - %e      )
                            - ----------------------
                                        2
 
 ```
-"""
-function exponentialize{T}(expr::T)
-    mexpr = MExpr(expr)
-    out = mcall(MExpr("exponentialize($mexpr)"))
-    convert(T, out)
-end
+""" exponentialize
 
-"""
+@doc """
     float(expr)
 
 Convert rational numbers into floating point numbers in expression.
@@ -396,17 +312,11 @@ Convert rational numbers into floating point numbers in expression.
 ## Examples
 ```julia
 julia> float(m\"1/3*x\")
- 
+
                              0.3333333333333333 x
 
 ```
-"""
-function float(expr::Union{Compat.String, Expr, MExpr})
-    T = typeof(expr)
-	mexpr = MExpr(expr)
-    out = mcall(MExpr("float($mexpr)"))
-    convert(T, out)
-end
+""" float
 
 """
     subst(a, b, expr)

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -43,19 +43,19 @@ for fun in simfun
       for h in 1:length(sexpr)
         if contains(sexpr[h],":=")
           sp = split(sexpr[h],":=")
-          push!(nsr,String(sp[1])*":="*string(sp[2] |> String |> MExpr |> $fun))
+          push!(nsr,Compat.String(sp[1])*":="*string(sp[2]|>Compat.String|>MExpr|> $fun))
         elseif contains(sexpr[h],"block([],")
           rp = replace(sexpr[h],"block([],","") |> chop
           sp = split(rp,",")
           ns = "block([],"
           for u in 1:length(sp)
-            ns = ns*string(sp[u] |> String |> MExpr |> $fun)
+            ns = ns*string(sp[u] |> Compat.String |> MExpr |> $fun)
           end
           ns = ns*")"
           push!(nsr,ns)
         elseif contains(sexpr[h],":")
           sp = split(sexpr[h],":")
-          push!(nsr,String(sp[1])*":"*string(sp[2] |> String |> MExpr |> parse))
+          push!(nsr,Compat.String(sp[1])*":"*string(sp[2]|>Compat.String|>MExpr|> $fun))
         else
           push!(nsr,$(string(fun))*"($(sexpr[h]))" |> MExpr |> mcall)
         end
@@ -175,19 +175,19 @@ function logexpand(m::MExpr)
   for h in 1:length(sexpr)
     if contains(sexpr[h],":=")
       sp = split(sexpr[h],":=")
-      push!(nsr,String(sp[1])*":="*string(sp[2] |> String |> MExpr |> logexpand))
+      push!(nsr,Compat.String(sp[1])*":="*string(sp[2]|>Compat.String|>MExpr|>logexpand))
     elseif contains(sexpr[h],"block([],")
       rp = replace(sexpr[h],"block([],","") |> chop
       sp = split(rp,",")
       ns = "block([],"
       for u in 1:length(sp)
-        ns = ns*string(sp[u] |> String |> MExpr |> logexpand)
+        ns = ns*string(sp[u] |> Compat.String |> MExpr |> logexpand)
       end
       ns = ns*")"
       push!(nsr,ns)
     elseif contains(sexpr[h],":")
       sp = split(sexpr[h],":")
-      push!(nsr,String(sp[1])*":"*string(sp[2] |> String |> MExpr |> parse))
+      push!(nsr,Compat.String(sp[1])*":"*string(sp[2]|>Compat.String|>MExpr|>logexpand))
     else
       push!(nsr,"$(sexpr[h]), logexpand=super" |> MExpr |> mcall)
     end
@@ -385,19 +385,19 @@ function subst(a, b, expr::MExpr)
   for h in 1:length(str)
     if contains(str[h],":=")
       sp = split(str[h],":=")
-      str[h] = String(str[1])*":="*(_subst(a,b,String(sp[2]))).str
+      str[h] = Compat.String(str[1])*":="*(_subst(a,b,Compat.String(sp[2]))).str
     elseif contains(str[h],"block([],")
       rp = replace(str[h],"block([],","") |> chop
       sp = split(rp,",")
       ns = "block([],"
       for u in 1:length(sp)
-        ns = ns*(_subst(a,b,String(sp[u]))).str
+        ns = ns*(_subst(a,b,Compat.String(sp[u]))).str
       end
       ns = ns*")"
       str[h] = ns
     elseif contains(str[h],":")
       sp = split(str[h],":")
-      str[h] = String(sp[1])*":"*(_subst(a,b,String(sp[2]))).str
+      str[h] = Compat.String(sp[1])*":"*(_subst(a,b,Compat.String(sp[2]))).str
     else
       str[h] = _subst(a, b, str[h])
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ catch err
     @test typeof(err) == ErrorException
 end
 
-@test sum(:(1 / k^2), :k, 1, Inf) == :(pi ^ 2 / 6)
+@test sum(:(1 / k^2), :k, 1, Inf) == :(π ^ 2 / 6)
 @test sum(m"1 / k ^ 2", :k, 1, "inf") == m"%pi^2/6"
 @test taylor(m"sin(x)", :x, 0, 3) == m"x - x^3/6"
 @test taylor(:(sin(x)), :x, 0, 3) == :(x - x^3/6)
@@ -46,7 +46,7 @@ end
 @test logexpand(m"log(x/y)") == m"log(x) - log(y)"
 @test trigsimp(m"sin(x)^2 + cos(x)^2") |> parse == 1
 @test trigrat(MExpr(:(exp(im*x) + exp(-im*x)))) == MExpr(:(2 * cos(x)))
-@test rectform(:(R*e^(im*theta))) == :(R * im * sin(theta) + R * cos(theta))
+@test rectform(:(R*e^(im*theta))) == :(im * R * sin(theta) + R * cos(theta))
 @test polarform(m"a + %i*b") == m"sqrt(a^2 + b^2)*exp(%i * atan2(b, a))"
 @test realpart(m"a + %i*b") |> parse == :a
 @test imagpart(m"a + %i*b") |> parse == :b

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ using Base.Test
 
 # Conversion and evaluation test
 @test m"expand((1+x)^2)" == m"1 + 2*x + x^2"
-@test mcall(:(exp(im*π))) == -1
+@test mcall(:(exp(im*pi))) == -1
 @test integrate(:(sin(x)), :x) == :(-cos(x))
 @test MExpr(:(100x)) == m"100 * x"
 @test MExpr(:(-im)) == m"-%i"
@@ -28,7 +28,7 @@ catch err
     @test typeof(err) == ErrorException
 end
 
-@test sum(:(1 / k^2), :k, 1, Inf) == :(π ^ 2 / 6)
+@test sum(:(1 / k^2), :k, 1, Inf) == :(pi ^ 2 / 6)
 @test sum(m"1 / k ^ 2", :k, 1, "inf") == m"%pi^2/6"
 @test taylor(m"sin(x)", :x, 0, 3) == m"x - x^3/6"
 @test taylor(:(sin(x)), :x, 0, 3) == :(x - x^3/6)
@@ -46,7 +46,7 @@ end
 @test logexpand(m"log(x/y)") == m"log(x) - log(y)"
 @test trigsimp(m"sin(x)^2 + cos(x)^2") |> parse == 1
 @test trigrat(MExpr(:(exp(im*x) + exp(-im*x)))) == MExpr(:(2 * cos(x)))
-@test rectform(:(R*e^(im*θ))) == :(R * im * sin(θ) + R * cos(θ))
+@test rectform(:(R*e^(im*theta))) == :(R * im * sin(theta) + R * cos(theta))
 @test polarform(m"a + %i*b") == m"sqrt(a^2 + b^2)*exp(%i * atan2(b, a))"
 @test realpart(m"a + %i*b") |> parse == :a
 @test imagpart(m"a + %i*b") |> parse == :b
@@ -74,5 +74,3 @@ try
 catch err
     @test typeof(err) == Maxima.MaximaSyntaxError
 end
-
-


### PR DESCRIPTION
This is a step towards the direction of what you want in #20 

```Julia
julia> fun = Expr(:function,:(f(x)),:(y = x+1; y^2)) |> MExpr
 
                                                     2
                       f(x) := block([], y : x + 1, y )

julia> string(fun)
"f(x):=block([],y:x+1,y^2)"

julia> fun |> mcall; mcall(:(f(11)))
144
```
You can now `unparse` a julia function expression that contains block quote expressions and evaluate it using maxima.

```Julia
julia> m"u+2; y^3-7; cos(3*%pi)+5" == :(u+2; y^3-7; cos(3*pi)+5) |> MExpr
true
```

Also, there are some other scattered minor improvements to the maxima session.Finally, the `simplify.jl` file has been rewritten to simplify management of very similar code.

All the tests are passsing on my end.

Please ask if the purpose of any of the changes are not clear. Mainly `mexpr.jl`, `io.jl` and `simplify.jl` were edited. Enjoy!