### PR TITLE
Remove support for v0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ os:
   - osx
 
 julia:
-  - 0.4
   - 0.5
   - 0.6
   - nightly

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.4
+julia 0.5
 Compat 0.9.5

--- a/src/mexpr.jl
+++ b/src/mexpr.jl
@@ -77,7 +77,7 @@ function unparse(expr::Expr)
     str = Array{Compat.String,1}(0)
     io = IOBuffer();
     if expr.head == :block
-        for line ∈ expr.args
+        for line in expr.args
             show_expr(io,line)
             push!(str,takebuf_string(io))
         end
@@ -124,7 +124,7 @@ end
 
 function mtrim(m::Array{Compat.String,1})
     n = Array{Compat.String,1}(0)
-    for h ∈ 1:length(m)
+    for h in 1:length(m)
         !isempty(m[h]) && push!(n,m[h])
     end
     return n
@@ -305,7 +305,7 @@ function ==(m::MExpr, n::MExpr)
     l=length(r)
     l!=length(s) && (return false)
     b = true
-    for j ∈ 1:l
+    for j in 1:l
         out = mcall("is($(r[j]) = $(s[j]))")
         b &= !contains(out,"false")
     end

--- a/src/server.jl
+++ b/src/server.jl
@@ -37,13 +37,6 @@ Base.kill(ms::MaximaSession) = kill(ms.process)
 Base.process_exited(ms::MaximaSession) = process_exited(ms.process)
 
 
-function Base.write(ms::MaximaSession, input::Compat.String)
-    # The line break right ..v.. there is apparently very important...
-    write(ms.input, "$input;\n")
-    write(ms.input, "print(ascii(4))\$")
-end
-
-
 if VERSION < v"0.5.0"
 
     function Base.write(ms::MaximaSession, input::UTF8String)
@@ -56,6 +49,13 @@ if VERSION < v"0.5.0"
         write(ms.input, "print(ascii(4))\$")
     end
 
+end
+
+
+function Base.write(ms::MaximaSession, input::Compat.String)
+    # The line break right ..v.. there is apparently very important...
+    write(ms.input, "$input;\n")
+    write(ms.input, "print(ascii(4))\$")
 end
 
 

--- a/src/server.jl
+++ b/src/server.jl
@@ -46,7 +46,7 @@ if VERSION < v"0.5"
         write(ms.input, "print(ascii(4))\$")
     end
 else 
-    function Base.write(ms::MaximaSession, input::AbstractString)
+    function Base.write(ms::MaximaSession, input::String)
         # The line break right ..v.. there is apparently very important...
         write(ms.input, "$input;\n")
         write(ms.input, "print(ascii(4))\$")

--- a/src/server.jl
+++ b/src/server.jl
@@ -6,7 +6,7 @@ const synerr = "incorrect syntax"
 const maxerr = "-- an error"
 
 
-immutable MaximaSession <: Base.AbstractPipe
+struct MaximaSession <: Base.AbstractPipe
 
     input::Pipe
     output::Pipe
@@ -35,21 +35,6 @@ end
 
 Base.kill(ms::MaximaSession) = kill(ms.process)
 Base.process_exited(ms::MaximaSession) = process_exited(ms.process)
-
-
-if VERSION < v"0.5.0"
-
-    function Base.write(ms::MaximaSession, input::UTF8String)
-        write(ms.input, "$input;\n")
-        write(ms.input, "print(ascii(4))\$")
-    end
-
-    function Base.write(ms::MaximaSession, input::ASCIIString)
-        write(ms.input, "$input;\n")
-        write(ms.input, "print(ascii(4))\$")
-    end
-
-end
 
 
 function Base.write(ms::MaximaSession, input::Compat.String)

--- a/src/server.jl
+++ b/src/server.jl
@@ -36,11 +36,21 @@ end
 Base.kill(ms::MaximaSession) = kill(ms.process)
 Base.process_exited(ms::MaximaSession) = process_exited(ms.process)
 
-
-function Base.write(ms::MaximaSession, input::Compat.String)
-    # The line break right ..v.. there is apparently very important...
-    write(ms.input, "$input;\n")
-    write(ms.input, "print(ascii(4))\$")
+if VERSION < v"0.5"
+    function Base.write(ms::MaximaSession, input::ASCIIString)
+        write(ms.input, "$input;\n")
+        write(ms.input, "print(ascii(4))\$")
+    end
+    function Base.write(ms::MaximaSession, input::UTF8String)
+        write(ms.input, "$input;\n")
+        write(ms.input, "print(ascii(4))\$")
+    end
+else 
+    function Base.write(ms::MaximaSession, input::AbstractString)
+        # The line break right ..v.. there is apparently very important...
+        write(ms.input, "$input;\n")
+        write(ms.input, "print(ascii(4))\$")
+    end
 end
 
 

--- a/src/server.jl
+++ b/src/server.jl
@@ -6,7 +6,7 @@ const synerr = "incorrect syntax"
 const maxerr = "-- an error"
 
 
-struct MaximaSession <: Base.AbstractPipe
+immutable MaximaSession <: Base.AbstractPipe
 
     input::Pipe
     output::Pipe

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -158,11 +158,12 @@ julia> expand(m\"(a + b)^2\")
 Contract logarithms in expression
 """ logcontract
 
-"""
+@doc """
     logexpand{T}(expr::T)
 
 Expand logarithm terms in an expression
 """ logexpand
+
 for t in ty
     quote
         function logexpand(expr::$t)


### PR DESCRIPTION
String issues and failing CI builds are becoming frustrating so lets just remove `v0.4` support. Upstream
is no longer maintaining v0.4 so this seems justified.