### PR TITLE
Change the type of args from String to Command

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -12,10 +12,10 @@ immutable MaximaSession <: Base.AbstractPipe
     output::Pipe
     process::Base.Process
 
-    function MaximaSession()
+    function MaximaSession(;ArgString="")
         # If windows, executable is .bat
-        cmd = is_unix() ? `maxima --very-quiet` :
-            `maxima.bat --very-quiet`
+        cmd = Sys.isunix() ? `maxima --very-quiet $ArgString` :
+            `maxima.bat --very-quiet $ArgString`
 
         # Setup pipes and maxima process
         input = Pipe()

--- a/src/server.jl
+++ b/src/server.jl
@@ -14,7 +14,7 @@ immutable MaximaSession <: Base.AbstractPipe
 
     function MaximaSession(;ArgString="")
         # If windows, executable is .bat
-        cmd = Sys.isunix() ? `maxima --very-quiet $ArgString` :
+        cmd = is_unix() ? `maxima --very-quiet $ArgString` :
             `maxima.bat --very-quiet $ArgString`
 
         # Setup pipes and maxima process

--- a/src/server.jl
+++ b/src/server.jl
@@ -12,7 +12,7 @@ immutable MaximaSession <: Base.AbstractPipe
     output::Pipe
     process::Base.Process
 
-    function MaximaSession(;args::Cmd=``)
+    function MaximaSession(;args::String="")
         # If windows, executable is .bat
         cmd = is_unix() ? `maxima --very-quiet $args` :
             `maxima.bat --very-quiet $args`

--- a/src/server.jl
+++ b/src/server.jl
@@ -12,7 +12,7 @@ immutable MaximaSession <: Base.AbstractPipe
     output::Pipe
     process::Base.Process
 
-    function MaximaSession(;args::String="")
+    function MaximaSession(;args::Cmd=``)
         # If windows, executable is .bat
         cmd = is_unix() ? `maxima --very-quiet $args` :
             `maxima.bat --very-quiet $args`

--- a/src/server.jl
+++ b/src/server.jl
@@ -12,10 +12,10 @@ immutable MaximaSession <: Base.AbstractPipe
     output::Pipe
     process::Base.Process
 
-    function MaximaSession(;ArgString="")
+    function MaximaSession(;args::String="")
         # If windows, executable is .bat
-        cmd = is_unix() ? `maxima --very-quiet $ArgString` :
-            `maxima.bat --very-quiet $ArgString`
+        cmd = is_unix() ? `maxima --very-quiet $args` :
+            `maxima.bat --very-quiet $args`
 
         # Setup pipes and maxima process
         input = Pipe()

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -6,7 +6,7 @@ __init__() = (Load(); atexit(() -> kill(ms)))
 
 function Load(;ArgString="")
     try
-        Sys.isunix() ? (@compat readstring(`maxima --version`)) :
+        is_unix() ? (@compat readstring(`maxima --version`)) :
             @compat readstring(`maxima.bat --version`)
     catch err
         error("Looks like Maxima is either not installed or not in the path")

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -6,7 +6,7 @@ __init__() = (Load(); atexit(() -> kill(ms)))
 
 function Load()
     try
-        is_unix() ? (@compat readstring(`maxima --version`)) :
+        Sys.isunix() ? (@compat readstring(`maxima --version`)) :
             @compat readstring(`maxima.bat --version`)
     catch err
         error("Looks like Maxima is either not installed or not in the path")

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -1,10 +1,10 @@
 #   This file is part of Maxima.jl. It is licensed under the MIT license
 #   Copyright (c) 2016 Nathan Smith
 
-Reset(;ArgString="") = (kill(ms); Load(ArgString=""))
+Reset(;args::String="") = (kill(ms); Load(args=args))
 __init__() = (Load(); atexit(() -> kill(ms)))
 
-function Load(;ArgString="")
+function Load(;args::String="")
     try
         is_unix() ? (@compat readstring(`maxima --version`)) :
             @compat readstring(`maxima.bat --version`)
@@ -14,7 +14,7 @@ function Load(;ArgString="")
 
     # Server setup
 
-    global ms = MaximaSession(ArgString="")	# Spin up a Maxima session
+    global ms = MaximaSession(args=args)	# Spin up a Maxima session
 
     # REPL setup
     repl_active = isdefined(Base, :active_repl)	# Is an active repl defined?

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -1,10 +1,10 @@
 #   This file is part of Maxima.jl. It is licensed under the MIT license
 #   Copyright (c) 2016 Nathan Smith
 
-Reset(;args::String="") = (kill(ms); Load(args=args))
+Reset(;args::Cmd=``) = (kill(ms); Load(args=args))
 __init__() = (Load(); atexit(() -> kill(ms)))
 
-function Load(;args::String="")
+function Load(;args::Cmd=``)
     try
         is_unix() ? (@compat readstring(`maxima --version`)) :
             @compat readstring(`maxima.bat --version`)

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -1,10 +1,10 @@
 #   This file is part of Maxima.jl. It is licensed under the MIT license
 #   Copyright (c) 2016 Nathan Smith
 
-Reset() = (kill(ms); Load())
+Reset(;ArgString="") = (kill(ms); Load(ArgString=""))
 __init__() = (Load(); atexit(() -> kill(ms)))
 
-function Load()
+function Load(;ArgString="")
     try
         Sys.isunix() ? (@compat readstring(`maxima --version`)) :
             @compat readstring(`maxima.bat --version`)
@@ -14,7 +14,7 @@ function Load()
 
     # Server setup
 
-    global ms = MaximaSession()	# Spin up a Maxima session
+    global ms = MaximaSession(ArgString="")	# Spin up a Maxima session
 
     # REPL setup
     repl_active = isdefined(Base, :active_repl)	# Is an active repl defined?

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -1,10 +1,10 @@
 #   This file is part of Maxima.jl. It is licensed under the MIT license
 #   Copyright (c) 2016 Nathan Smith
 
-Reset(;args::Cmd=``) = (kill(ms); Load(args=args))
+Reset(;args::String="") = (kill(ms); Load(args=args))
 __init__() = (Load(); atexit(() -> kill(ms)))
 
-function Load(;args::Cmd=``)
+function Load(;args::String="")
     try
         is_unix() ? (@compat readstring(`maxima --version`)) :
             @compat readstring(`maxima.bat --version`)
@@ -30,4 +30,5 @@ function Load(;args::Cmd=``)
     end
 
     mcall("1") # clears out any initial data
+    return nothing
 end


### PR DESCRIPTION
The way Julia interpolates strings into commands involves automatically adding quotes that broke the use case for which the `args` functionality was originally added. Specifically, `args="-X '--dynamic-space-size 4096'"` was supposed to generate `` `maxima --very-quiet -X '--dynamic-space-size 4096'` `` as the command. Instead, it generated `` `maxima --very-quiet "-X '--dynamic-space-size 4096'"` ``. The simplest solution was to change the type of args to also be `Cmd`. 