### PR TITLE
change e to \euler as used in julia 1.x

### DIFF
--- a/src/mexpr.jl
+++ b/src/mexpr.jl
@@ -142,7 +142,7 @@ end
 
 
 const m_to_jl = Dict(
-    "%e"     => "e",
+    "%e"     => "ℯ",
     "%pi"    =>  "π",
     "%i"     =>  "im",
     "%gamma" => "eulergamma",
@@ -152,8 +152,7 @@ const m_to_jl = Dict(
 )
 
 const jl_to_m = Dict(
-    "e"          => "%e",
-    "eu"         => "%e",
+    "ℯ"          => "%e",
     "pi"         => "%pi",
     "π"          => "%pi",
     "γ"          => "%gamma",


### PR DESCRIPTION
A minor fix for the `e` constant.